### PR TITLE
Smooth scroll more (or all) operations that move the window

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,28 +35,28 @@ hook global WinCreate .* %{ hook -once window WinDisplay .* smooth-scroll-enable
 ### Customizing mapped keys
 Keys that are mapped for each mode are customized via the `scroll_keys_normal`, `scroll_keys_goto` and `scroll_keys_object` options. If for a mode the corresponding option is not set, keys that are mapped by default are the following:
 
-| **normal**                                                          |
-| ------                                                              |
-|`<c-f>`, `<pagedown>`, `<c-b>`, `<pageup>`, (scroll one page down/up)|
-|`<c-d>`, `<c-u>` (scroll half a page down/up)                        |
-|`)`, `(` (rotate main selection forward/backward)                    |
-|`m`, `M` (select/extend to next matching character)                  |
-|`<a-semicolon>` (flip direction of selection)                        |
-|`<percent>` (select whole buffer)                                    |
-|`n`, `<a-n>`, `N`, `<a-N>` (select/extend to next/previous match)    |
+| **normal** keys                           | description                              |
+| ------                                    | ------                                   |
+|`<c-f>`, `<pagedown>`, `<c-b>`, `<pageup>` | scroll one page down/up                  |
+|`<c-d>`, `<c-u>`                           | scroll half a page down/up               |
+|`)`, `(`                                   | rotate main selection forward/backward   |
+|`m`, `M`                                   | select/extend to next matching character |
+|`<a-semicolon>` (`<a-;>`)                  | flip direction of selection              |
+|`<percent>` (`%`)                          | select whole buffer                      |
+|`n`, `<a-n>`, `N`, `<a-N>`                 | select/extend to next/previous match     |
 
-| **goto**               |
-| ------                 |
-|`g`, `k` (buffer top)   |
-|`j` (buffer bottom)     |
-|`e` (buffer end)        |
-|`.` (last buffer change)|
+| **goto** keys                             | description                              |
+| ------                                    | ------                                   |
+|`g`, `k`                                   | buffer top                               |
+|`j`                                        | buffer bottom                            |
+|`e`                                        | buffer end                               |
+|`.`                                        | last buffer change                       |
 
-| **object**                 |
-| ------                     |
-|`p` (paragraph)             |
-|`i` (indent)                |
-|`B`, `{`, `}` (braces block)|
+| **object** keys                           | description                              |
+| ------                                    | ------                                   |
+|`p`                                        | paragraph                                |
+|`i`                                        | indent                                   |
+|`B`, `{`, `}`                              | braces block                             |
 
 Default behavior is equivalent to the following configuration:
 

--- a/README.md
+++ b/README.md
@@ -105,5 +105,8 @@ set-option global scroll_options speed=0 interval=10 max_duration=500
   - This implementation utilizes Kakoune's internal [remote API](https://github.com/mawww/kakoune/blob/master/src/remote.hh), so it may break with future Kakoune versions
   - A more performant implementation with pure `kak`/`sh` should be possible if [timer hooks](https://github.com/mawww/kakoune/issues/2337#issuecomment-416531650) become available
 
+## Acknowledgments
+Thanks @Screwtapello and @Guest0x0 for valuable feedback and fixes!
+
 ## License
 MIT

--- a/README.md
+++ b/README.md
@@ -5,46 +5,105 @@ Smooth scrolling for the [Kakoune](https://kakoune.org) text editor, with inerti
 
 This plugin implements smooth scrolling similar to various plugins for Vim/Emacs etc. such as [vim-smooth-scroll](https://github.com/terryma/vim-smooth-scroll).
 It gives you better visual feedback while scrolling and arguably helps you preserve your "sense of place" when making large jumps such as when using `<c-f>/<c-b>` movements.
+The latest version of the plugin adds support for many keys in `normal`, `goto` and `object` modes; see the "Configuration" section below.
 
 For that extra fun/coolness factor it also has support for inertial scrolling, also called the "easing out" or "soft stop" effect as seen above.
 This is similar to myriad plugins such as [comfortable-motion.vim](https://github.com/yuttie/comfortable-motion.vim), [vim-smoothie](https://github.com/psliwka/vim-smoothie/) and [sexy-scroller.vim](https://github.com/joeytwiddle/sexy_scroller.vim).
 
-## Caveats
-- Relies on `vj` and `vk` for scrolling, but always moves the cursor unlike native `<c-d>/<c-u>` et al.
-This is to avoid issues with scrolling across wrapped lines similar to [kakoune#1517](https://github.com/mawww/kakoune/issues/1517).
-- For optimal performance it uses a Python implementation which requires Python 3.6+ in path, falling back to `sh` if not available
-  - This implementation utilizes Kakoune's internal [remote API](https://github.com/mawww/kakoune/blob/master/src/remote.hh), so it may break with future Kakoune versions
-  - A more performant implementation with pure `kak`/`sh` should be possible if [timer hooks](https://github.com/mawww/kakoune/issues/2337#issuecomment-416531650) become available
-
 ## Installation
-Download `smooth-scroll.kak` and `smooth-scroll.py` to your `autoload` folder, e.g. into `~/.config/kak/autoload`. If you are using [plug.kak](https://gitlab.com/andreyorst/plug.kak):
+Download `smooth-scroll.kak` and `smooth-scroll.py` to your `autoload` folder, e.g. into `~/.config/kak/autoload`.
+Or you can put them both in any location and `source path/to/smooth-scroll.kak` in your `kakrc`.
+
+If you are using [plug.kak](https://github.com/andreyorst/plug.kak):
 ```kak
 plug "caksoylar/kakoune-smooth-scroll" config %{
-     # mappings here
+     # configuration here
 }
 ```
 
 ## Configuration
+kakoune-smooth-scroll operates through a mapping mechanism for keys in `normal`, `goto` and `object` modes.
+Mapped keys will perform their usual functions but when they need to scroll the window the scrolling will happen smoothly.
 
-You need to map the necessary keys if you want to use smooth scrolling to replace the default. Below are suggested mappings with inertial scrolling (replace `0` with `1` for linear scrolling):
+Smooth scrolling is enabled and disabled on a per-window basis using `smooth-scroll-enable` and `smooth-scroll-disable` commands.
+If you would like to automatically enable it for every window, you can use window-based hooks:
+
 ```kak
-# suggested mappings (python)
-map global normal <c-d> ': smooth-scroll  0.5 20 0<ret>'
-map global normal <c-u> ': smooth-scroll -0.5 20 0<ret>'
-map global normal <c-f> ': smooth-scroll  1.0 10 0<ret>'
-map global normal <c-b> ': smooth-scroll -1.0 10 0<ret>'
+hook global WinCreate .* %{ hook -once window WinDisplay .* smooth-scroll-enable }
 ```
 
-If you can't use the Python version for any reason, I suggest below mappings:
+### Customizing mapped keys
+Keys that are mapped for each mode are customized via the `scroll_keys_normal`, `scroll_keys_goto` and `scroll_keys_object` options. If for a mode the corresponding option is not set, keys that are mapped by default are the following:
+
+| **normal**                                                          |
+| ------                                                              |
+|`<c-f>`, `<pagedown>`, `<c-b>`, `<pageup>`, (scroll one page down/up)|
+|`<c-d>`, `<c-u>` (scroll half a page down/up)                        |
+|`)`, `(` (rotate main selection forward/backward)                    |
+|`m`, `M` (select/extend to next matching character)                  |
+|`<a-semicolon>` (flip direction of selection)                        |
+|`<percent>` (select whole buffer)                                    |
+|`n`, `<a-n>`, `N`, `<a-N>` (select/extend to next/previous match)    |
+
+| **goto**               |
+| ------                 |
+|`g`, `k` (buffer top)   |
+|`j` (buffer bottom)     |
+|`e` (buffer end)        |
+|`.` (last buffer change)|
+
+| **object**                 |
+| ------                     |
+|`p` (paragraph)             |
+|`i` (indent)                |
+|`B`, `{`, `}` (braces block)|
+
+Default behavior is equivalent to the following configuration:
+
 ```kak
-# suggested mappings (sh)
-map global normal <c-d> ': smooth-scroll  0.5 40 2<ret>'
-map global normal <c-u> ': smooth-scroll -0.5 40 2<ret>'
-map global normal <c-f> ': smooth-scroll  1.0 20 2<ret>'
-map global normal <c-b> ': smooth-scroll -1.0 20 2<ret>'
+set-option global scroll_keys_normal <c-f> <c-b> <c-d> <c-u> <pageup> <pagedown> ( ) m M <a-semicolon> <percent> n <a-n> N <a-N>
+set-option global scroll_keys_goto g j k e .
+set-option global scroll_keys_object p i B { }
 ```
 
-You can play with the second and third parameters to find the feel that you like. See `:smooth-scroll` function documentation for details.
+You can override which keys are mapped for each mode by setting the corresponding option.
+For example if you only want to map page-wise motions in `normal` mode and disable any mappings for `goto` mode, you can configure it as such:
+
+```kak
+set-option global scroll_keys_normal <c-f> <c-b> <c-d> <c-u>
+set-option global scroll_keys_goto
+```
+
+By default each listed key is mapped to its regular function.
+You might want to customize source and destination keys for each map, especially if you are already mapping other keys to these functions.
+For instance if you use `<c-j>` instead of `<c-f>` and `<c-k>` instead of `<c-b>`, you can specify the option using `src=dst` pairs:
+
+```kak
+set-option global scroll_keys_normal <c-j>=<c-f> <c-k>=<c-b> <c-d> <c-u>
+```
+
+Note that these options need to be set before smooth scrolling is enabled for a window.
+
+### Scrolling parameters
+There are a few parameters related to the scrolling behavior that are adjustable through the `scroll_options` option which is a list of `<key>=<value>` pairs. Following keys are accepted and all of them are optional:
+- `speed`: number of lines to scroll per tick, `0` for inertial scrolling (default: `0`)
+- `interval`: average milliseconds between each scroll (default: `10`)
+- `max_duration`: maximum duration of a scroll in milliseconds (default: `500`)
+
+The default configuration is equivalent to:
+
+```kak
+set-option global scroll_options speed=0 interval=10 max_duration=500
+```
+
+## Caveats
+- Smooth scrolling is not performed for movements that do not modify the selection, such as any movement through the `view` mode. See [related Kakoune issue](https://github.com/mawww/kakoune/issues/3616)
+- Keys that modify the buffer should not be mapped, such as `u` and `U` in `normal` mode, since the implementation discards any buffer modifications made by mapped keys
+- Movements that are caused by the `prompt` mode such as `/search_word<ret>` can not be mapped at the moment
+- Repeating selections with `<a-.>` is not possible if the selection was made through mapped keys
+- For optimal performance it uses a Python implementation which requires Python 3.6+ in path, falling back to `sh` if not available
+  - This implementation utilizes Kakoune's internal [remote API](https://github.com/mawww/kakoune/blob/master/src/remote.hh), so it may break with future Kakoune versions
+  - A more performant implementation with pure `kak`/`sh` should be possible if [timer hooks](https://github.com/mawww/kakoune/issues/2337#issuecomment-416531650) become available
 
 ## License
 MIT

--- a/smooth-scroll.kak
+++ b/smooth-scroll.kak
@@ -93,7 +93,10 @@ define-command smooth-scroll-move -params 1 -hidden -override %{
             echo "echo -debug kakoune-smooth-scroll: WARNING -- cannot execute python version, falling back to pure sh"
         fi
 
-        eval $kak_opt_scroll_options
+        eval "$kak_opt_scroll_options"
+        speed=${speed:-0}
+        interval=${interval:-10}
+        max_duration=${max_duration:-1000}
         if [ "$speed" -eq 0 ]; then
             speed=1
         fi

--- a/smooth-scroll.kak
+++ b/smooth-scroll.kak
@@ -168,7 +168,7 @@ define-command smooth-scroll-do-key -params 2 -hidden %{
                 # scroll to new position smoothly (selection will be restored when done)
                 printf 'execute-keys <space>\n'
                 printf 'smooth-scroll-move %s\n' "$diff"
-                return
+                exit 0
             fi
         fi
         # we haven't moved the viewport enough so just apply selection 

--- a/smooth-scroll.kak
+++ b/smooth-scroll.kak
@@ -103,7 +103,7 @@ define-command smooth-scroll-enable -docstring "enable smooth scrolling for wind
     # done scrolling, so restore cursor highlighting and original selection
     hook -group scroll window WinSetOption scroll_running= %{
         evaluate-commands -client %opt{scroll_client} %{
-            select %opt{scroll_selections}
+            try %{ select %opt{scroll_selections} }
         }
         unset-face window PrimaryCursor
         unset-face window PrimaryCursorEol

--- a/smooth-scroll.kak
+++ b/smooth-scroll.kak
@@ -183,7 +183,7 @@ define-command smooth-scroll-move -params 1 -hidden %{
         if type python3 >/dev/null 2>&1 && [ -f "$kak_opt_scroll_py" ]; then
             python3 "$kak_opt_scroll_py" "$amount" >/dev/null 2>&1 </dev/null &
             printf 'set-option window scroll_running %s\n' "$!"
-            return
+            exit 0
         fi
 
         # fall back to pure sh

--- a/smooth-scroll.kak
+++ b/smooth-scroll.kak
@@ -5,7 +5,7 @@ declare-option -hidden str scroll_client
 declare-option -hidden str-list scroll_selections
 
 # user-facing
-declare-option str-to-str-map scroll_options speed=0 duration=10
+declare-option str-to-str-map scroll_options speed=0 interval=10 max_duration=1000
 
 define-command smooth-scroll-disable -override %{
     remove-hooks window scroll

--- a/smooth-scroll.kak
+++ b/smooth-scroll.kak
@@ -154,7 +154,7 @@ define-command smooth-scroll-map-key -params 3 -docstring %{
 define-command smooth-scroll-do-key -params 2 -hidden %{
     # execute key in draft context to figure out the final selection and window_range
     evaluate-commands -draft %{
-        execute-keys %arg{2} %arg{1}
+        execute-keys %val{count} %arg{2} %arg{1}
         set-option window scroll_window %val{window_range}
         set-option window scroll_selections %val{selections_desc}
     }

--- a/smooth-scroll.kak
+++ b/smooth-scroll.kak
@@ -156,7 +156,7 @@ define-command smooth-scroll-disable -docstring "disable smooth scrolling for wi
     unset-face window PrimaryCursorEol
 }
 
-define-command smooth-scroll-do-key -params 2 -hidden -override %{
+define-command smooth-scroll-do-key -params 2 -hidden %{
     # execute key in draft context to figure out the final selection and window_range
     evaluate-commands -draft %{
         execute-keys %arg{2} %arg{1}
@@ -181,7 +181,7 @@ define-command smooth-scroll-do-key -params 2 -hidden -override %{
     }
 }
 
-define-command smooth-scroll-move -params 1 -hidden -override %{
+define-command smooth-scroll-move -params 1 -hidden %{
     evaluate-commands %sh{
         amount=$1
         # try to run the python version

--- a/smooth-scroll.kak
+++ b/smooth-scroll.kak
@@ -19,7 +19,8 @@ define-command smooth-scroll-enable -override %{
 
     hook -group scroll window NormalIdle .* smooth-scroll
     # hook -group scroll window NormalKey .* smooth-scroll
-    # hook -group scroll window RawKey .* smooth-scroll
+    # hook -group scroll window ModeChange pop:.*:normal smooth-scroll
+    # hook -group scroll window RawKey [^:/ia].* smooth-scroll
 
     set-option window scroll_running false
     set-option window scroll_window %val{window_range}
@@ -43,6 +44,7 @@ define-command smooth-scroll-enable -override %{
         # restore cursor highlighting and original selection
         evaluate-commands -client %opt{scroll_client} %{
             select %opt{scroll_selections}
+            set-option window scroll_window %val{window_range}
         }
         unset-face window PrimaryCursor
         unset-face window PrimaryCursorEol
@@ -53,10 +55,10 @@ define-command smooth-scroll-enable -override %{
 define-command smooth-scroll -hidden -override %{
     evaluate-commands %sh{
         if [ "$kak_window_range" != "$kak_opt_scroll_window" ] && [ "$kak_opt_scroll_running" = "false" ]; then
-            # printf '%s\n' "echo -debug $kak_window_range -> $kak_opt_scroll_window"
             diff=$(( ${kak_window_range%% *} - ${kak_opt_scroll_window%% *} ))
             abs_diff=${diff#-}
             if [ "$abs_diff" -gt 10 ]; then
+                # printf '%s\n' "echo -debug $kak_opt_scroll_window -> $kak_window_range"
                 printf '%s\n' "set-option window scroll_selections %val{selections_desc}"
                 printf '%s\n' "set-option window scroll_window %val{window_range}"
                 printf '%s\n' "set-option window scroll_running true"
@@ -71,9 +73,9 @@ define-command smooth-scroll -hidden -override %{
 
                 # scroll to new position smoothly
                 printf '%s\n' "smooth-scroll-move $diff"
-                return
+            else
+                printf '%s\n' "set-option window scroll_window %val{window_range}"
             fi
-            printf '%s\n' "set-option window scroll_window %val{window_range}"
         fi
     }
 }

--- a/smooth-scroll.kak
+++ b/smooth-scroll.kak
@@ -19,6 +19,7 @@ define-command smooth-scroll-enable -override %{
 
     hook -group scroll window NormalIdle .* smooth-scroll
     # hook -group scroll window NormalKey .* smooth-scroll
+    # hook -group scroll window RawKey .* smooth-scroll
 
     set-option window scroll_running false
     set-option window scroll_window %val{window_range}
@@ -34,7 +35,8 @@ define-command smooth-scroll-enable -override %{
     hook -group scroll window WinSetOption scroll_running=true %{
         # make cursor invisible to make scroll less jarring
         set-face window PrimaryCursor @default
-        set-face window PrimaryCursorEol @default"
+        set-face window PrimaryCursorEol @default
+        set-face window LineNumberCursor @LineNumbers
     }
 
     hook -group scroll window WinSetOption scroll_running=false %{
@@ -44,6 +46,7 @@ define-command smooth-scroll-enable -override %{
         }
         unset-face window PrimaryCursor
         unset-face window PrimaryCursorEol
+        unset-face window LineNumberCursor
     }
 }
 
@@ -61,9 +64,9 @@ define-command smooth-scroll -hidden -override %{
                 # scroll back to original position
                 printf '%s\n' "execute-keys <space>"
                 if [ "$abs_diff" = "$diff" ]; then
-                    printf '%s\n' "execute-keys ${abs_diff}k${abs_diff}vk"
+                    printf '%s\n' "execute-keys ${abs_diff}vk"
                 else
-                    printf '%s\n' "execute-keys ${abs_diff}j${abs_diff}vj"
+                    printf '%s\n' "execute-keys ${abs_diff}vj"
                 fi
 
                 # scroll to new position smoothly

--- a/smooth-scroll.kak
+++ b/smooth-scroll.kak
@@ -3,6 +3,7 @@ declare-option -hidden bool scroll_running false
 declare-option -hidden str scroll_window
 declare-option -hidden str scroll_client
 declare-option -hidden str-list scroll_selections
+declare-option -hidden bool scroll_fallback false
 
 # user-facing
 declare-option str-to-str-map scroll_options speed=0 interval=10 max_duration=1000
@@ -48,12 +49,6 @@ define-command smooth-scroll-enable -override %{
 
 define-command smooth-scroll -hidden -override %{
     evaluate-commands %sh{
-        # make these available to the python script
-        # shellcheck disable=SC2034
-        options=$kak_opt_scroll_options
-        session=$kak_session
-        client=$kak_client
-
         if [ "$kak_window_range" != "$kak_opt_scroll_window" ] && [ "$kak_opt_scroll_running" = "false" ]; then
             # printf '%s\n' "echo -debug $kak_window_range -> $kak_opt_scroll_window"
             diff=$(( ${kak_window_range%% *} - ${kak_opt_scroll_window%% *} ))
@@ -72,10 +67,62 @@ define-command smooth-scroll -hidden -override %{
                 fi
 
                 # scroll to new position smoothly
-                python3 "$kak_opt_scroll_py" "$diff" >/dev/null 2>&1 </dev/null &
+                printf '%s\n' "smooth-scroll-move $diff"
                 return
             fi
+            printf '%s\n' "set-option window scroll_window %val{window_range}"
         fi
-        printf '%s\n' "set-option window scroll_window %val{window_range}"
+    }
+}
+
+define-command smooth-scroll-move -params 1 -hidden -override %{
+    evaluate-commands %sh{
+        amount=$1
+        # try to run the python version
+        if type python3 >/dev/null 2>&1 && [ -f "$kak_opt_scroll_py" ]; then
+            python3 "$kak_opt_scroll_py" "$amount" >/dev/null 2>&1 </dev/null &
+            return
+        fi
+
+        # fall back to pure sh
+        if [ "$kak_opt_scroll_fallback" = "false" ]; then
+            printf '%s\n' "set-option global scroll_fallback true"
+            echo "echo -debug kakoune-smooth-scroll: WARNING -- cannot execute python version, falling back to pure sh"
+        fi
+
+        eval $kak_opt_scroll_options
+        if [ "$speed" -eq 0 ]; then
+            speed=1
+        fi
+
+        abs_amount=${amount#-}
+        if [ "$abs_amount" = "$amount" ]; then
+            keys="${speed}j${speed}vj"
+        else
+            keys="${speed}k${speed}vk"
+        fi
+        cmd="printf 'execute-keys -client %s %s\\n' ""$kak_client"" ""$keys"" | kak -p ""$kak_session"""
+
+        times=$(( abs_amount / speed ))
+        if [ $(( times * interval )) -gt "$max_duration" ]; then
+            interval=0
+        fi
+        (
+            i=0
+            t1=$(date +%s.%N)
+            while [ $i -lt $times ]; do
+                eval "$cmd"
+                if [ "$interval" -gt 0 ]; then
+                    t2=$(date +%s.%N)
+                    sleep_for=$(printf 'scale=3; %f/1000 - (%f - %f)\n' "$interval" "$t2" "$t1" | bc)
+                    if [ "$sleep_for" -gt 0 ]; then
+                        sleep "$sleep_for"
+                    fi
+                    t1=$t2
+                fi
+                i=$(( i + 1 ))
+            done
+            printf "eval -client %s '%s'\\n" "$kak_client" "set-option window scroll_running false" | kak -p "$kak_session" 
+        ) >/dev/null 2>&1 </dev/null &
     }
 }

--- a/smooth-scroll.kak
+++ b/smooth-scroll.kak
@@ -1,30 +1,81 @@
 declare-option -hidden str scroll_py %sh{printf "%s" "${kak_source%.kak}.py"}
-declare-option -hidden bool scroll_fallback false
 declare-option -hidden bool scroll_running false
-declare-option -hidden str scroll_window "-100 0 0 0"
+declare-option -hidden str scroll_window
+declare-option -hidden str scroll_client
 declare-option -hidden str-list scroll_selections
+
+# user-facing
 declare-option str-to-str-map scroll_options speed=0 duration=10
 
-remove-hooks global scroll 
-hook -group scroll global NormalIdle .* smooth-scroll
-hook -group scroll global NormalKey .* smooth-scroll
+define-command smooth-scroll-disable -override %{
+    remove-hooks window scroll
+    unset-face window PrimaryCursor
+    unset-face window PrimaryCursorEol
+}
 
-define-command smooth-scroll -override %{
+define-command smooth-scroll-enable -override %{
+    smooth-scroll-disable
+
+    hook -group scroll window NormalIdle .* smooth-scroll
+    # hook -group scroll window NormalKey .* smooth-scroll
+
+    set-option window scroll_running false
+    set-option window scroll_window %val{window_range}
+    set-option window scroll_client %val{client}
+
+    # hook -group scroll window WinSetOption scroll_selections=.* %{
+    #     echo -debug "selections: %opt{scroll_selections}"
+    # }
+    # hook -group scroll window WinSetOption scroll_window=.* %{
+    #     echo -debug "window: %opt{scroll_window}"
+    # }
+
+    hook -group scroll window WinSetOption scroll_running=true %{
+        # make cursor invisible to make scroll less jarring
+        set-face window PrimaryCursor @default
+        set-face window PrimaryCursorEol @default"
+    }
+
+    hook -group scroll window WinSetOption scroll_running=false %{
+        # restore cursor highlighting and original selection
+        evaluate-commands -client %opt{scroll_client} %{
+            select %opt{scroll_selections}
+        }
+        unset-face window PrimaryCursor
+        unset-face window PrimaryCursorEol
+    }
+}
+
+define-command smooth-scroll -hidden -override %{
     evaluate-commands %sh{
-        if [ "$kak_window_range" != "$kak_opt_scroll_window" -a "$kak_opt_scroll_running" = "false" ]; then
-            printf '%s\n' "echo -debug $kak_window_range -> $kak_opt_scroll_window"
-            printf '%s\n' "set-option window scroll_selections %val{selections_desc}"
+        # make these available to the python script
+        # shellcheck disable=SC2034
+        options=$kak_opt_scroll_options
+        session=$kak_session
+        client=$kak_client
+
+        if [ "$kak_window_range" != "$kak_opt_scroll_window" ] && [ "$kak_opt_scroll_running" = "false" ]; then
+            # printf '%s\n' "echo -debug $kak_window_range -> $kak_opt_scroll_window"
             diff=$(( ${kak_window_range%% *} - ${kak_opt_scroll_window%% *} ))
-            selections=$kak_selections_desc
-            options=$kak_opt_scroll_options
-            session=$kak_session
-            client=$kak_client
-            if [ "${diff#-}" -gt 10 ]; then
-                printf '%s\n' "echo -debug -- $diff"
-                printf '%s\n' "set-option global scroll_running true"
-                python3 "$kak_opt_scroll_py" "$kak_opt_scroll_window" "$kak_window_range" >/dev/null 2>&1 </dev/null &
+            abs_diff=${diff#-}
+            if [ "$abs_diff" -gt 10 ]; then
+                printf '%s\n' "set-option window scroll_selections %val{selections_desc}"
+                printf '%s\n' "set-option window scroll_window %val{window_range}"
+                printf '%s\n' "set-option window scroll_running true"
+
+                # scroll back to original position
+                printf '%s\n' "execute-keys <space>"
+                if [ "$abs_diff" = "$diff" ]; then
+                    printf '%s\n' "execute-keys ${abs_diff}k${abs_diff}vk"
+                else
+                    printf '%s\n' "execute-keys ${abs_diff}j${abs_diff}vj"
+                fi
+
+                # scroll to new position smoothly
+                python3 "$kak_opt_scroll_py" "$diff" >/dev/null 2>&1 </dev/null &
+                return
             fi
         fi
+        printf '%s\n' "set-option window scroll_window %val{window_range}"
     }
-    set-option window scroll_window %val{window_range}
 }

--- a/smooth-scroll.py
+++ b/smooth-scroll.py
@@ -106,14 +106,9 @@ def inertial_scroll(sender: KakSender, target: int, duration: float) -> None:
 def main() -> None:
     """
     Do smooth scrolling using KakSender methods. Expected positional arguments:
-        amount:   number of lines to scroll as the fraction of a full screen
-                  positive for down, negative for up, e.g. 1 for <c-f>, -0.5 for <c-u>
-        duration: amount of time between each scroll tick, in milliseconds
-        speed:    number of lines to scroll with each tick, 0 for inertial scrolling
+        amount:   number of lines to scroll; positive for down, negative for up
     """
-    initial_window = sys.argv[1].split()
-    new_window = sys.argv[2].split()
-    selections = os.environ['kak_selections_desc']
+    amount = int(sys.argv[1])
     options = parse_options("scroll_options")
     duration = (
         float(options["duration"]) / 1000
@@ -122,20 +117,10 @@ def main() -> None:
 
     sender = KakSender()
 
-    # make cursor invisible to make scroll less jarring
-    sender.send_keys("<space>")
-    sender.send_cmd(
-        "set-face window PrimaryCursor @default; set-face window PrimaryCursorEol @default",
-        client=True,
-    )
-
-    amount = int(new_window[0]) - int(initial_window[0])
     n_lines = abs(amount)
     sign = 1 if amount > 0 else -1
 
-    scroll_once(sender, -amount, 0)  # scroll back to initial position
-
-    # smoothly scroll back
+    # smoothly scroll to target
     if speed > 0 or duration < 1e-3:  # fixed speed scroll
         times = n_lines // max(speed, 1)
         for i in range(times):
@@ -143,13 +128,8 @@ def main() -> None:
     else:  # inertial scroll
         inertial_scroll(sender, sign * n_lines, duration)
 
-    # restore selections, cursor face and note we are done
-    sender.send_cmd(f"select {selections}", client=True)
-    sender.send_cmd(
-        "unset-face window PrimaryCursor; unset-face window PrimaryCursorEol",
-        client=True
-    )
-    sender.send_cmd("set-option global scroll_running false")
+    # note we are done
+    sender.send_cmd("set-option window scroll_running false", client=True)
 
 
 if __name__ == '__main__':

--- a/smooth-scroll.py
+++ b/smooth-scroll.py
@@ -119,7 +119,7 @@ def main() -> None:
     sender = KakSender()
 
     n_lines = abs(amount)
-    interval = min(interval,  max_duration / (n_lines - 1))
+    interval = min(interval, max_duration / (n_lines - 1))
     sign = 1 if amount > 0 else -1
 
     # smoothly scroll to target
@@ -131,7 +131,7 @@ def main() -> None:
         inertial_scroll(sender, sign * n_lines, interval)
 
     # note we are done
-    sender.send_cmd("set-option window scroll_running false", client=True)
+    sender.send_cmd('set-option window scroll_running ""', client=True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Following @Screwtapello's suggestions: Instead of specializing for 4 movements only (`<c-f>`, `<c-b>`, `<c-d>`, `<c-u>`), try to implement smooth scrolling for either all operations that move the window through hooks, or at the least more keys that can be mapped to scroll the window smoothly. See discussion on the discourse: https://discuss.kakoune.com/t/a-smooth-scrolling-plugin-for-kakoune
1. Hook approach (`hook-based` branch) hooks to `NormalIdle`, `NormalKey` or `RawKey` events. Essentially it keeps track of the movement that triggered the hook, undoes it, then does it again but smoothly (saving and restoring selections)
    - This has the disadvantage of flickering the screen between the hook trigger and the undo scroll (especially for `NormalIdle` hook)
    - Able to catch most events, although each hook type has its own advantages/disadvantages
2. Mapping approach (current branch) maps a list of given keys to a method that executes them in a draft context to obtain final position and selections, then scrolls there smoothly and restores the selections
    - This avoids the flickering, since the initial move doesn't happen in the client context
    - Major disadvantage is dealing with already mapped keys: We either do nothing for those keys or override the existing mappings
    - Kakoune does not preserve the viewport in draft context if selection doesn't change, see [this issue](https://github.com/mawww/kakoune/issues/3616) -- so `view` mode mappings don't smoothly scroll, along with `<c-d>`/`<c-u>`/`<c-f>`/`<c-b>` in some cases
    - Another disadvantage is that likely not everything can be mapped this way
      - Anything that actually modifies the buffer like `u` and `U`
      - Movements that relate to prompt mode like pressing `<ret>` after `/` search (new position not correctly calculated in draft context)