### PR TITLE
Add early stopping if maximum scrolling duration is exceeded

### DIFF
--- a/smooth-scroll.py
+++ b/smooth-scroll.py
@@ -81,6 +81,16 @@ def scroll_once(sender: KakSender, step: int, interval: float) -> None:
         time.sleep(interval - elapsed)
 
 
+def linear_scroll(sender: KakSender, target: int, speed: int, interval: float) -> None:
+    """
+    Do linear scrolling with fixed velocity.
+    """
+    n_lines, step = abs(target), speed if target > 0 else -speed
+    times = n_lines // max(speed, 1)
+    for i in range(times):
+        scroll_once(sender, step, interval * (i < times - 1))
+
+
 def inertial_scroll(sender: KakSender, target: int, interval: float) -> None:
     """
     Do inertial scrolling with initial velocity decreasing linearly at each
@@ -122,17 +132,13 @@ def scroll() -> None:
 
     sender = KakSender()
 
-    n_lines = abs(amount)
-    interval = min(interval, max_duration / (n_lines - 1))
-    sign = 1 if amount > 0 else -1
+    interval = min(interval, max_duration / (abs(amount) - 1))
 
     # smoothly scroll to target
     if speed > 0 or interval < 1e-3:  # fixed speed scroll
-        times = n_lines // max(speed, 1)
-        for i in range(times):
-            scroll_once(sender, sign * speed, interval * (i < times - 1))
+        linear_scroll(sender, amount, speed, interval)
     else:  # inertial scroll
-        inertial_scroll(sender, sign * n_lines, interval)
+        inertial_scroll(sender, amount, interval)
 
     # report we are done
     sender.send_cmd('set-option window scroll_running ""', client=True)

--- a/smooth-scroll.py
+++ b/smooth-scroll.py
@@ -88,7 +88,12 @@ def linear_scroll(sender: KakSender, target: int, speed: int, duration: float) -
     n_lines, step = abs(target), speed if target > 0 else -speed
     times = n_lines // max(speed, 1)
     interval = duration / (times - 1)
+
+    t_init = time.time()
     for i in range(times):
+        if time.time() - t_init > duration:
+            scroll_once(sender, step * (times - i), 0)
+            break
         scroll_once(sender, step, interval * (i < times - 1))
 
 
@@ -107,7 +112,12 @@ def inertial_scroll(sender: KakSender, target: int, duration: float) -> None:
     n_lines, step = abs(target), 1 if target > 0 else -1
     velocity = n_lines * sum(1.0 / x for x in range(2, n_lines + 1)) / duration  # type: ignore
     d_velocity = velocity / n_lines
+
+    t_init = time.time()
     for i in range(n_lines):
+        if time.time() - t_init > duration:
+            scroll_once(sender, step * (n_lines - i), 0)
+            break
         scroll_once(sender, step, 1 / velocity * (i < n_lines - 1))
         velocity -= d_velocity
 


### PR DESCRIPTION
In certain systems or through certain connections, scrolling one tick can take much longer than expected. In that case we can scroll as fast as we can but still not be able to finish in the maximum specified duration. This is exacerbated by scrolling large amounts, e.g. `gj` in a long file.

This adds a timer check at each tick so that if max duration is exceeded, the scrolling just jumps to the final position.

Also included are some reformatting and renaming changes.