### PR TITLE
Batch scroll events to rate-limit sending commands to Kakoune

### DIFF
--- a/smooth-scroll.py
+++ b/smooth-scroll.py
@@ -9,6 +9,8 @@ import os
 import time
 import socket
 
+SEND_THRESHOLD = 5e-3  # min time in s between sending two scroll events
+
 
 class KakSender:
     """Helper to communicate with Kakoune's remote API using Unix sockets."""
@@ -113,14 +115,27 @@ def inertial_scroll(sender: KakSender, target: int, duration: float) -> None:
     velocity = n_lines * sum(1.0 / x for x in range(2, n_lines + 1)) / duration  # type: ignore
     d_velocity = velocity / n_lines
 
+    # keep track of total steps and interval for potential batching
+    # before sending a scroll event
+    q_step, q_duration = 0, 0.
+
     t_init = time.time()
     for i in range(n_lines):
         # shortcut to the end if we are past total duration
         if time.time() - t_init > duration:
             scroll_once(sender, step * (n_lines - i), 0)
             break
-        scroll_once(sender, step, 1 / velocity * (i < n_lines - 1))
+
+        interval = 1 / velocity * (i < n_lines - 1)
         velocity -= d_velocity
+
+        # update queue check if we are past the event send interval
+        q_duration += interval
+        q_step += step
+        # print(interval, q_duration, q_step)
+        if i == n_lines - 1 or q_duration >= SEND_THRESHOLD:
+            scroll_once(sender, q_step, q_duration)
+            q_step, q_duration = 0, 0.
 
 
 def scroll() -> None:

--- a/smooth-scroll.py
+++ b/smooth-scroll.py
@@ -9,7 +9,7 @@ import os
 import time
 import socket
 
-SEND_INTERVAL = 1e-3  # min time interval (in s) between two sent scroll events
+SEND_INTERVAL = 2e-3  # min time interval (in s) between two sent scroll events
 
 
 class KakSender:

--- a/smooth-scroll.py
+++ b/smooth-scroll.py
@@ -9,7 +9,7 @@ import os
 import time
 import socket
 
-SEND_THRESHOLD = 5e-3  # min time in s between sending two scroll events
+SEND_INTERVAL = 1e-3  # min time interval (in s) between two sent scroll events
 
 
 class KakSender:
@@ -126,14 +126,14 @@ def inertial_scroll(sender: KakSender, target: int, duration: float) -> None:
             scroll_once(sender, step * (n_lines - i), 0)
             break
 
+        # compute sleep interval and update velocity
         interval = 1 / velocity * (i < n_lines - 1)
         velocity -= d_velocity
 
-        # update queue check if we are past the event send interval
+        # update queue then check if we are past the event send interval
         q_duration += interval
         q_step += step
-        # print(interval, q_duration, q_step)
-        if i == n_lines - 1 or q_duration >= SEND_THRESHOLD:
+        if i == n_lines - 1 or q_duration >= SEND_INTERVAL:
             scroll_once(sender, q_step, q_duration)
             q_step, q_duration = 0, 0.
 


### PR DESCRIPTION
For scrolling very long distances or if `interval` option value is very small, the rate at which we send scroll events to Kakoune can be very high. This sometimes leads to Kakoune not being able to process the events in time, especially if we are doing anything more complicated than a view scroll at each tick (see [`scrollbar` branch](https://github.com/caksoylar/kakoune-smooth-scroll/tree/scrollbar)). This leads to the window freezing then scrolling at once to the final location.

To solve this we can queue scroll events together and send a single event to scroll multiple lines at once when we are past a certain time interval. Current threshold accounts for ~500Hz updates which seems generous enough for high refresh screens, while reducing the stutter for slower machines or over remote connections.

In general this will let us be a better citizen by not overwhelming Kakoune with a lot of commands through the remote API. It will also reduce the times where we need to shortcut to the end because we haven't finished scrolling in `max_duration`.