### PR TITLE
Add integration with scrollbar.kak

### DIFF
--- a/smooth-scroll.kak
+++ b/smooth-scroll.kak
@@ -8,7 +8,8 @@ declare-option -docstring %{
                       scrolling (default: 0)
         interval:     average milliseconds between each scroll (default: 10)
         max_duration: maximum duration of a scroll in milliseconds (default: 500)
-} str-to-str-map scroll_options speed=0 interval=10 max_duration=500
+        scrollbar:    whether to trigger the "view-modified" hook used by scrollbar.kak (default: no)
+} str-to-str-map scroll_options speed=0 interval=10 max_duration=500 scrollbar=no
 
 declare-option -docstring %{
     list of keys to apply smooth scrolling in normal mode. Specify only keys
@@ -95,6 +96,7 @@ define-command smooth-scroll-enable -docstring "enable smooth scrolling for wind
     hook -group scroll window WinSetOption scroll_running= %{
         evaluate-commands -client %opt{scroll_client} %{
             try %{ select %opt{scroll_selections} }
+            trigger-user-hook view-scrolled
         }
         unset-face window PrimaryCursor
         unset-face window PrimaryCursorEol

--- a/smooth-scroll.py
+++ b/smooth-scroll.py
@@ -77,6 +77,7 @@ def scroll_once(sender: KakSender, step: int, interval: float) -> None:
     speed = abs(step)
     keys = f"{speed}j{speed}vj" if step > 0 else f"{speed}k{speed}vk"
     sender.send_keys(keys)
+    sender.send_cmd("trigger-user-hook view-scrolled", client=True)
     t_end = time.time()
     elapsed = t_end - t_start
     if elapsed < interval:


### PR DESCRIPTION
Trigger the hook that tells [scrollbar.kak](https://github.com/sawdust-and-diamonds/scrollbar.kak) that the view is scrolled so it can update the scrollbar display, but only when smooth scrolling operation is finished with default settings. Also add a new key to `scrollbar` to `scroll_options` that is bool-valued (`yes`/`true` or `no`/`false`) that forces a scrollbar update **during** smooth scrolling. This is off by default due to performance implications.

Waiting for https://github.com/sawdust-and-diamonds/scrollbar.kak/pull/6 to be merged first and still needs a README update.