### PR TITLE
Change the type of `scroll_window` variable to a `str-list` from `str`

### DIFF
--- a/smooth-scroll.kak
+++ b/smooth-scroll.kak
@@ -43,7 +43,7 @@ declare-option -docstring %{
 declare-option -hidden str scroll_py %sh{printf "%s" "${kak_source%.kak}.py"}  # python script path
 declare-option -hidden bool scroll_fallback false  # remember if we fell back to sh impl
 declare-option -hidden str scroll_running ""       # pid of scroll process if it running
-declare-option -hidden str scroll_window           # new location after a key press
+declare-option -hidden str-list scroll_window      # new location after a key press
 declare-option -hidden str-list scroll_selections  # new selections after a key press
 declare-option -hidden str scroll_client           # store for WinSetOption hook which runs in draft context
 declare-option -hidden str scroll_mode             # key we used to enter a mode so we can replicate it


### PR DESCRIPTION
The smooth scroll plugin recently stopped working for me in kakoune. When I tried to press `ctrl+f` I would get an error rather than a scroll !

Upon investigating I found that since [fc7be678ed0ec7](https://github.com/mawww/kakoune/commit/fc7be678ed0ec7) in kakoune, `%val{window_range}` is output as separate strings.

The fix is straight forward.

